### PR TITLE
fix(gke): compatible resource naming

### DIFF
--- a/gcp/gke/main.tf
+++ b/gcp/gke/main.tf
@@ -37,7 +37,7 @@ resource "google_container_node_pool" "primary_nodes" {
 
     # preemptible  = true
     machine_type = "e2-highmem-4"
-    tags         = ["gke-node", "${var.project_id}-gke"]
+    tags         = ["gke-node", "quickstart-${var.cluster_name}"]
     metadata = {
       disable-legacy-endpoints = "true"
     }

--- a/gcp/gke/variables.tf
+++ b/gcp/gke/variables.tf
@@ -6,7 +6,7 @@ variable "cluster_name" {
   default     = "otomi-quickstart"
   validation {
     condition     = can(regex("^(?:[a-z](?:[-a-z0-9]{0,61}[a-z0-9])?)$", var.cluster_name))
-    error_message = "The cluster_name value must be lowercase and cannot start or end with non-alfanumerical character."
+    error_message = "The cluster_name value must be lowercase and cannot start or end with non-alfanumeric character."
   }
 }
 variable "env_name" {

--- a/gcp/gke/variables.tf
+++ b/gcp/gke/variables.tf
@@ -4,11 +4,17 @@ variable "project_id" {
 variable "cluster_name" {
   description = "The name for the GKE cluster"
   default     = "otomi-quickstart"
+  validation {
+    condition     = can(regex("^(?:[a-z](?:[-a-z0-9]{0,61}[a-z0-9])?)$", var.cluster_name))
+    error_message = "The cluster_name value must match regex pattern."
+  }
 }
 variable "env_name" {
   description = "The environment for the GKE cluster"
   default     = "quickstart"
 }
+
+
 variable "region" {
   description = "The region to host the cluster in"
   default     = "europe-west4"

--- a/gcp/gke/variables.tf
+++ b/gcp/gke/variables.tf
@@ -6,7 +6,7 @@ variable "cluster_name" {
   default     = "otomi-quickstart"
   validation {
     condition     = can(regex("^(?:[a-z](?:[-a-z0-9]{0,61}[a-z0-9])?)$", var.cluster_name))
-    error_message = "The cluster_name value must be lowercase and cannot start or end with non-alfanumeric character."
+    error_message = "The cluster_name value must be lowercase and cannot start or end with non-alphanumeric character."
   }
 }
 variable "env_name" {

--- a/gcp/gke/variables.tf
+++ b/gcp/gke/variables.tf
@@ -6,7 +6,7 @@ variable "cluster_name" {
   default     = "otomi-quickstart"
   validation {
     condition     = can(regex("^(?:[a-z](?:[-a-z0-9]{0,61}[a-z0-9])?)$", var.cluster_name))
-    error_message = "The cluster_name value must match regex pattern."
+    error_message = "The cluster_name value must be lowercase and cannot start or end with non-alfanumerical character."
   }
 }
 variable "env_name" {

--- a/gcp/gke/vpc.tf
+++ b/gcp/gke/vpc.tf
@@ -5,13 +5,13 @@ provider "google" {
 
 # VPC
 resource "google_compute_network" "vpc" {
-  name                    = "${var.project_id}-vpc"
+  name                    = "quickstart-${var.cluster_name}"
   auto_create_subnetworks = "false"
 }
 
 # Subnet
 resource "google_compute_subnetwork" "subnet" {
-  name          = "${var.project_id}-subnet"
+  name          = "quickstart-${var.cluster_name}"
   region        = var.region
   network       = google_compute_network.vpc.name
   ip_cidr_range = "10.10.0.0/24"


### PR DESCRIPTION
Prevent following errors while ` terraform apply` for gke

```                                                                                           (⎈ otomi-eks-jeho:default)
╷
│ Error: "name" ("498923989146-subnet") doesn't match regexp "^(?:[a-z](?:[-a-z0-9]{0,61}[a-z0-9])?)$"
│ 
│   with google_compute_subnetwork.subnet,
│   on vpc.tf line 14, in resource "google_compute_subnetwork" "subnet":
│   14:   name          = "${var.project_id}-subnet"
```
```
│ Error: Error creating Network: googleapi: Error 400: Invalid value for field 'resource.name': '498923989146-vpc'. Must be a match of regex '(?:[a-z](?:[-a-z0-9]{0,61}[a-z0-9])?)', invalid
│ 
│   with google_compute_network.vpc,
│   on vpc.tf line 7, in resource "google_compute_network" "vpc":
│    7: resource "google_compute_network" "vpc" {
```