### PR TITLE
Walkthrough var.profile and documentation

### DIFF
--- a/aws/README.md
+++ b/aws/README.md
@@ -5,6 +5,12 @@
 - [AWS CLI](https://aws.amazon.com/cli/)
 - [Terraform](https://cloud.google.com/sdk/docs/install)
 
+### Additional resources
+
+- If you use VSCode, hover over variables to see the description/type in .tf and .tfvars files with the [Terraform extension](https://marketplace.visualstudio.com/items?itemName=HashiCorp.terraform).
+- [Official module documentation]()
+- [How to setup awsci and terraform](https://learn.hashicorp.com/tutorials/terraform/aws-build)
+
 #### AWS CLI Cheat Sheet
 
 ```bash
@@ -27,6 +33,7 @@ aws iam list-groups
 - Open a terminal and run the following:
 
 ```bash
+cd aws/eks # if you haven't done so already
 # Initializes the directory
 terraform init
 # Sets up the EKS cluster
@@ -35,13 +42,14 @@ terraform apply
 
 ---
 
-### Install Otomi
+### Install Otomi on EKS
 
 - Navigate to the `otomi-install` directory
 - Copy `terraform.tfvars.example` file to `terraform.tfvars` file and fill in missing configuration parameters
 - Open a terminal and run the following:
 
 ```bash
+cd aws/otomi-install # if you haven't done so already
 # Initializes the directory
 terraform init
 # Deploys and otomi installer job on the EKS cluster

--- a/aws/eks/.terraform.lock.hcl
+++ b/aws/eks/.terraform.lock.hcl
@@ -3,9 +3,10 @@
 
 provider "registry.terraform.io/hashicorp/aws" {
   version     = "3.63.0"
-  constraints = ">= 3.22.0, >= 3.40.0, >= 3.56.0, >= 3.63.0"
+  constraints = ">= 3.25.0, >= 3.40.0, >= 3.56.0, >= 3.63.0"
   hashes = [
     "h1:Z+2GvXLgqQ/uPMH8dv+dXJ/t+jd6sriYjhCJS6kSO6g=",
+    "h1:v9aPF3aaBpk0uSO5pfggYJKGgP/Ur28hZRJs1jS+ttI=",
     "zh:42c6c98b294953a4e1434a331251e539f5372bf6779bd61ab5df84cac0545287",
     "zh:5493773762a470889c9a23db97582d3a82035847c8d3bd13323b4c3012abf325",
     "zh:550d22ff9fed4d817a922e7b84bd9d1f2ef8d3afa00832cf66b8cd5f0e6dc748",
@@ -25,6 +26,7 @@ provider "registry.terraform.io/hashicorp/cloudinit" {
   constraints = ">= 2.0.0"
   hashes = [
     "h1:siiI0wK6/jUDdA5P8ifTO0yc9YmXHml4hz5K9I9N+MA=",
+    "h1:tQLNREqesrdCQ/bIJnl0+yUK+XfdWzAG0wo4lp10LvM=",
     "zh:76825122171f9ea2287fd27e23e80a7eb482f6491a4f41a096d77b666896ee96",
     "zh:795a36dee548e30ca9c9d474af9ad6d29290e0a9816154ad38d55381cd0ab12d",
     "zh:9200f02cb917fb99e44b40a68936fd60d338e4d30a718b7e2e48024a795a61b9",
@@ -61,6 +63,7 @@ provider "registry.terraform.io/hashicorp/kubernetes" {
   version     = "2.0.3"
   constraints = ">= 1.11.1, ~> 2.0.1"
   hashes = [
+    "h1:bWKA/gbCuIArnpNYZrc73LBhVwRZOLfb06Z7fk8HcKQ=",
     "h1:u3QLP3ca1ZYtdx4t9LrNLzAA3HY/GAT06hznb2pqNC4=",
     "zh:3847733636ed2aca8694227ee6936fecc6cec9573818ecf64acc2a01a4fb3ae4",
     "zh:44d3e88227174d2e51e0273e732e54bb5f5d8150bbf1adecd2be198c857a0264",
@@ -80,6 +83,7 @@ provider "registry.terraform.io/hashicorp/local" {
   version     = "2.1.0"
   constraints = ">= 1.4.0"
   hashes = [
+    "h1:EYZdckuGU3n6APs97nS2LxZm3dDtGqyM4qaIvsmac8o=",
     "h1:KfieWtVyGWwplSoLIB5usKAUnrIkDQBkWaR5TI+4WYg=",
     "zh:0f1ec65101fa35050978d483d6e8916664b7556800348456ff3d09454ac1eae2",
     "zh:36e42ac19f5d68467aacf07e6adcf83c7486f2e5b5f4339e9671f68525fc87ab",
@@ -119,6 +123,7 @@ provider "registry.terraform.io/terraform-aws-modules/http" {
   constraints = ">= 2.4.1"
   hashes = [
     "h1:FINkX7/X/cr5NEssB7dMqVWa6YtJtmwzvkfryuR39/k=",
+    "h1:ZnkXcawrIr611RvZpoDzbtPU7SVFyHym+7p1t+PQh20=",
     "zh:0111f54de2a9815ded291f23136d41f3d2731c58ea663a2e8f0fef02d377d697",
     "zh:0740152d76f0ccf54f4d0e8e0753739a5233b022acd60b5d2353d248c4c17204",
     "zh:569518f46809ec9cdc082b4dfd4e828236eee2b50f87b301d624cfd83b8f5b0d",

--- a/aws/eks/provider.tf
+++ b/aws/eks/provider.tf
@@ -1,5 +1,6 @@
 provider "aws" {
   region = var.aws_region
+  profile = var.aws_profile
 }
 
 provider "kubernetes" {

--- a/aws/eks/terraform.tfvars.example
+++ b/aws/eks/terraform.tfvars.example
@@ -11,7 +11,7 @@ aws_profile = "default"
 # Optional variables, uncomment to customize the quickstart
 # ----------------------------------------------------------
 
-# AWS IAM Roles
+# AWS IAM Roles - this will be used later to decide who can access the cluster
 # aws_roles = [
 #   {
 #     rolearn  = "arn:aws:iam::222222222222:user1/username"
@@ -20,7 +20,7 @@ aws_profile = "default"
 #   },
 # ]
 
-# AWS IAM Users
+# AWS IAM Users - this will be used later to decide who can access the cluster
 # aws_users = [
 #   {
 #     rolearn  = "arn:aws:iam::222222222222:user1/username"

--- a/aws/eks/terraform.tfvars.example
+++ b/aws/eks/terraform.tfvars.example
@@ -3,29 +3,31 @@
 # - Check variables.tf for variable type(includes defaults)
 # ==========================================================
 
-# AWS Accounts
+# AWS Accounts - this will be used later to decide who can access the cluster
 aws_accounts = ["222222222222"]
 
-# AWS IAM Roles
-aws_roles = [
-  {
-    rolearn  = "arn:aws:iam::222222222222:user1/username"
-    username = "username"
-    groups   = ["Admins"]
-  },
-]
-
-# AWS IAM Users
-aws_users = [
-  {
-    rolearn  = "arn:aws:iam::222222222222:user1/username"
-    username = "username"
-    groups   = ["Admins"]
-  },
-]
+aws_profile = "default"
 
 # Optional variables, uncomment to customize the quickstart
 # ----------------------------------------------------------
+
+# AWS IAM Roles
+# aws_roles = [
+#   {
+#     rolearn  = "arn:aws:iam::222222222222:user1/username"
+#     username = "username"
+#     groups   = ["Admins"]
+#   },
+# ]
+
+# AWS IAM Users
+# aws_users = [
+#   {
+#     rolearn  = "arn:aws:iam::222222222222:user1/username"
+#     username = "username"
+#     groups   = ["Admins"]
+#   },
+# ]
 
 # EKS Cluster Name (default: otomi-quickstart)
 # cluster_name = ""

--- a/aws/eks/variables.tf
+++ b/aws/eks/variables.tf
@@ -1,4 +1,8 @@
-
+variable "aws_profile" {
+  description = "If you use another profiles besides [default], then also set this tfvar to the other profile."
+  type = string
+  default = "default"
+}
 
 variable "aws_accounts" {
   description = "Additional AWS account numbers to add to the aws-auth configmap."

--- a/aws/eks/variables.tf
+++ b/aws/eks/variables.tf
@@ -1,5 +1,5 @@
 variable "aws_profile" {
-  description = "If you use another profiles besides [default], then also set this tfvar to the other profile."
+  description = "Set this variable if you use another profile besides the default awscli profile called 'default'."
   type = string
   default = "default"
 }


### PR DESCRIPTION
I attempted `terraform apply` in the `eks/` folder. If a user uses at least 2 profiles (in my case `default` and `2auth`), then in our code we assume that the default user has permission to interact with AWS. In my case, only `2auth` has access, but I was unable to set the profile. I went through the official docs to figure it out. I modified the documentation with my observations.