### PR TITLE
fix: mitigate issue with missing project id

### DIFF
--- a/gcp/README.md
+++ b/gcp/README.md
@@ -18,10 +18,6 @@ gcloud auth application-default login
 # Enable google services api
 gcloud services enable compute.googleapis.com
 gcloud services enable container.googleapis.com
-
-# In case of `Error: project: required field is not set`
-# export the env variable with the project name
-export GOOGLE_PROJECT=YOUR_PROJECT_NAME
 ```
 
 ---

--- a/gcp/otomi-install/helm_release.tf
+++ b/gcp/otomi-install/helm_release.tf
@@ -1,8 +1,10 @@
-data "google_client_config" "provider" {}
+data "google_client_config" "provider" {
+}
 
 data "google_container_cluster" "primary" {
   name     = var.gke_cluster_name
   location = var.region
+  project  = var.project_id
 }
 
 provider "kubernetes" {

--- a/gcp/otomi-install/variables.tf
+++ b/gcp/otomi-install/variables.tf
@@ -1,3 +1,7 @@
+variable "project_id" {
+  description = "The gcloud project ID"
+  type        = string
+}
 variable "gke_cluster_name" {
   description = "The name for the GKE cluster"
   type        = string


### PR DESCRIPTION
Explicitly require `project_id`
Solve the following issue
```
│ Error: project: required field is not set
│ 
│   with data.google_container_cluster.primary,
│   on helm_release.tf line 3, in data "google_container_cluster" "primary":
│    3: data "google_container_cluster" "primary" {
```