### PR TITLE
Remove k8sVersion dependency

### DIFF
--- a/aws/eks/example.tfvars
+++ b/aws/eks/example.tfvars
@@ -37,7 +37,7 @@ cluster_name = "otomi"
 aws_region = "eu-central-1"
 
 # Kubernetes version used for creating workload cluster(default: 1.21)
-cluster_version = "1.24"
+cluster_version = "1.26"
 
 instance_types = ["c5.xlarge"]
 

--- a/aws/eks/variables.tf
+++ b/aws/eks/variables.tf
@@ -61,7 +61,7 @@ variable "cluster_name" {
 variable "cluster_version" {
   type        = string
   description = "AWS EKS cluster version"
-  default     = "1.24"
+  default     = "1.26"
 }
 
 variable "environment" {

--- a/aws/otomi/example.tfvars
+++ b/aws/otomi/example.tfvars
@@ -11,6 +11,3 @@ cluster_name = "otomi"
 
 # AWS region for all resources(default: eu-central-1)
 aws_region = "eu-central-1"
-
-# Kubernetes version used for creating workload cluster(default: 1.24)
-cluster_version = "1.24"

--- a/aws/otomi/example.yaml
+++ b/aws/otomi/example.yaml
@@ -1,12 +1,11 @@
 cluster:
   owner: my-company # Replace it with your company name
-  k8sVersion: "1.24" # One of Last 3 k8s versions which are supported by Otomi
   name: otomi # Keep it same as your EKS cluster name
   provider: aws # Don't change
   apiName: otomi # Don't change
   region: eu-central-1 # your region
 otomi:
-  version: "v0.21.5" # Otomi application version
+  # version: "v0.26.1" # Otomi application version
   adminPassword: "welcomeotomi" # If you neglect this line, otomi will create a random password which can be supplied at the end of Job Log
 # kms:
 #   sops:

--- a/aws/otomi/variables.tf
+++ b/aws/otomi/variables.tf
@@ -8,9 +8,3 @@ variable "cluster_name" {
   description = "Name of the EKS cluster"
   default     = "otomi-eks-quickstart"
 }
-
-variable "cluster_version" {
-  type        = string
-  description = "AWS EKS cluster version"
-  default     = "1.23"
-}

--- a/azure/README.md
+++ b/azure/README.md
@@ -47,7 +47,7 @@ az aks create --name $CLUSTER_NAME \
 --nodepool-name otomipool \
 --node-count 3 \
 --node-vm-size Standard_F8s_v2 \
---kubernetes-version 1.23.15 \
+--kubernetes-version 1.26.9 \
 --enable-cluster-autoscaler \
 --min-count 1 \
 --max-count 6 \
@@ -72,7 +72,7 @@ az aks get-credentials -n $CLUSTER_NAME -g $RGNAME
 helm repo add otomi https://otomi.io/otomi-core 
 helm repo update
 # Otomi install with minimal chart values
-helm install otomi otomi/otomi --set cluster.k8sVersion="1.23" --set cluster.name=$CLUSTER_NAME --set cluster.provider=azure
+helm install otomi otomi/otomi --set cluster.name=$CLUSTER_NAME --set cluster.provider=azure
 ```
 
 The helm chart deploys an installer job responsible for installing the Otomi platform on the AKS cluster.

--- a/gcp/README.md
+++ b/gcp/README.md
@@ -59,7 +59,7 @@ gcloud container clusters get-credentials $CLUSTER_NAME --region $COMPUTE_REGION
 helm repo add otomi https://otomi.io/otomi-core 
 helm repo update
 # Otomi install with minimal chart values
-helm install otomi otomi/otomi --set cluster.k8sVersion="1.21" --set cluster.name=$CLUSTER_NAME --set cluster.provider=google
+helm install otomi otomi/otomi --set cluster.name=$CLUSTER_NAME --set cluster.provider=google
 ```
 
 The Helm chart deploys an installer job responsible for installing Otomi on the GKE cluster.

--- a/linode/README.md
+++ b/linode/README.md
@@ -30,7 +30,7 @@ export KUBECONFIG=<path-to-downloads>/otomi-quickstart-kubeconfig.yaml
 helm repo add otomi https://otomi.io/otomi-core
 helm repo update
 # Otomi install with minimal chart values
-helm install otomi otomi/otomi --set cluster.k8sVersion="1.22" --set cluster.name=otomi-quickstart --set cluster.provider=custom
+helm install otomi otomi/otomi --set cluster.name=otomi-quickstart --set cluster.provider=custom
 ```
 
 The helm chart deploys an installer job responsible for installing Otomi on the GKE cluster.

--- a/minikube/README.md
+++ b/minikube/README.md
@@ -37,25 +37,25 @@
 ### For Windows
 
 ```bash
-minikube start --memory=8192 --cpus=8 --driver=hyperv --kubernetes-version=v1.23.17 --cni calico
+minikube start --memory=8192 --cpus=8 --driver=hyperv --kubernetes-version=v1.26.9 --cni calico
 ```
 
 ### For Mac
 
 ```bash
-minikube start --memory=8192 --cpus=8 --driver=hyperkit --kubernetes-version=v1.23.17 --cni calico
+minikube start --memory=8192 --cpus=8 --driver=hyperkit --kubernetes-version=v1.26.9 --cni calico
 ```
 
 ### For Linux, using the KVM2 driver
 
 ```bash
-minikube start --memory=8192 --cpus=8 --driver=kvm2 --kubernetes-version=v1.23.17 --cni calico
+minikube start --memory=8192 --cpus=8 --driver=kvm2 --kubernetes-version=v1.26.9 --cni calico
 ```
 
 ### For using the Docker driver (Recommended for Apple M1 Chip)
 
 ```bash
-minikube start --memory=8192 --cpus=8 --driver=docker --kubernetes-version=v1.23.17 --cni calico
+minikube start --memory=8192 --cpus=8 --driver=docker --kubernetes-version=v1.26.9 --cni calico
 ```
 
 ## Enable Metallb (Network Load Balancer)
@@ -135,7 +135,7 @@ helm repo update
 ### Otomi install with minimal chart values
 
 ```bash
-helm install otomi otomi/otomi --set cluster.k8sVersion="1.23" --set cluster.name=minikube --set cluster.provider=custom --set apps.host-mods.enabled=false --set apps.metrics-server.extraArgs.kubelet-insecure-tls=true --set apps.metrics-server.extraArgs.kubelet-preferred-address-types=InternalIP
+helm install otomi otomi/otomi --set cluster.name=minikube --set cluster.provider=custom --set apps.host-mods.enabled=false --set apps.metrics-server.extraArgs.kubelet-insecure-tls=true --set apps.metrics-server.extraArgs.kubelet-preferred-address-types=InternalIP
 ```
 
 The helm chart deploys an installer job responsible for installing the Otomi platform on the minikube cluster.


### PR DESCRIPTION
Since Otomi v0.26.1 the k8sVersion is not required in the values file for Otomi Helm chart